### PR TITLE
chore: temporarily configured PyPi API key for the authentication

### DIFF
--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -297,7 +297,6 @@ jobs:
         permissions:
             contents: read
             packages: write
-            id-token: write
         steps:
             - name: Download Python artifacts
               uses: actions/download-artifact@v4
@@ -309,6 +308,7 @@ jobs:
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   skip-existing: true
+                  password: ${{ secrets.PYPI_TOKEN }}
 
             - name: Log success
               run: |


### PR DESCRIPTION
This pull request makes minor updates to the `.github/workflows/milestone-release.yml` workflow configuration. The main changes involve improving security and ensuring the correct authentication for publishing Python packages.

* Security improvement: Removed the unnecessary `id-token: write` permission from the workflow to reduce the permissions granted during the release process.
* Publishing configuration: Added the `password` input to the PyPI publishing step, using the `PYPI_TOKEN` secret for authentication.