### PR TITLE
fix: set release mode as draft in semantic-release configuration to enable attaching release assets later in the workflow

### DIFF
--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -579,6 +579,19 @@ jobs:
                     echo "⚠️ Database server zip not found"
                   fi
 
+            - name: Publish the release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  VERSION="${{ needs.release.outputs.version }}"
+
+                  echo "Publishing release v$VERSION..."
+
+                  # Publish the release (change from draft to published)
+                  gh release edit "v$VERSION" --draft=false
+
+                  echo "✅ Release v$VERSION has been published!"
+
     no-release-needed:
         needs: check-milestone
         if: needs.check-milestone.outputs.has_release_commits == 'false'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -113,7 +113,7 @@
                     "released on ${nextRelease.gitTag}"
                 ],
                 "addReleases": "bottom",
-                "draftRelease": false
+                "draftRelease": true
             }
         ]
     ]


### PR DESCRIPTION
This update modifies the `.releaserc.json` file to set the `draftRelease` option to true, allowing releases to be created as drafts. Additionally, the milestone release workflow is enhanced with a new step to publish the release, transitioning it from draft to published status using the GitHub CLI. This change improves the release process by providing more control over the visibility of new releases before they are officially published.

Close #28 