### PR TITLE
fix: fixed an issue in the version information formatting in pyprojec…

### DIFF
--- a/ragora/pyproject.toml
+++ b/ragora/pyproject.toml
@@ -151,4 +151,8 @@ markers = [
 
 [tool.setuptools_scm]
 write_to = "ragora/_version.py"
-write_to_template = '"""Version information for the ragora package."""\n\n__version__ = "{version}"\n__version_info__ = tuple(map(int, __version__.split(".")))\n'
+write_to_template = """\"\"\"Version information for the ragora package.\"\"\"
+
+__version__ = "{version}"
+__version_info__ = tuple(map(int, __version__.split(".")))
+"""


### PR DESCRIPTION
This pull request makes a small formatting change to the `write_to_template` string in the `[tool.setuptools_scm]` section of `ragora/pyproject.toml`. The template is now written using triple quotes and improved line breaks, which enhances readability and maintainability.