### PR TITLE
chore: configure git user identity for commit amendment in release workflow

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -340,6 +340,11 @@ jobs:
               LAST_COMMIT_MSG=$(git log -1 --format="%s" 2>/dev/null || echo "")
               if echo "$LAST_COMMIT_MSG" | grep -q "chore(release)"; then
                 echo "📝 Amending semantic-release commit with cleaned CHANGELOG.md..."
+                
+                # Configure git user identity for commit amendment
+                git config user.name "github-actions[bot]"
+                git config user.email "github-actions[bot]@users.noreply.github.com"
+                
                 git add CHANGELOG.md
                 git commit --amend --no-edit
                 echo "✅ Commit amended with cleaned CHANGELOG.md"


### PR DESCRIPTION
This update adds configuration for the git user identity in the `release-core.yml` workflow, ensuring that the bot's identity is used when amending commits with a cleaned `CHANGELOG.md`. This change enhances the clarity and traceability of automated commit amendments during the release process.