### PR TITLE
fix: fixed the use of filter parameter naming in Retriever class

### DIFF
--- a/ragora/ragora/core/retriever.py
+++ b/ragora/ragora/core/retriever.py
@@ -49,7 +49,8 @@ class Retriever:
 
         Args:
             db_manager: DatabaseManager instance for database access
-            embedding_engine: EmbeddingEngine instance (optional, defaults to None)
+            embedding_engine: EmbeddingEngine instance
+                (optional, defaults to None)
 
         Raises:
             ValueError: If db_manager is None
@@ -111,7 +112,7 @@ class Retriever:
                 query=processed_query,
                 limit=top_k,
                 return_metadata=MetadataQuery(distance=True),
-                filter=filter,
+                filters=filter,
             )
 
             # Process results
@@ -149,7 +150,8 @@ class Retriever:
             alpha: Weight for vector search (0.0 = keyword only,
                 1.0 = vector only)
             score_threshold: Minimum similarity score threshold
-            filter: Optional Weaviate Filter object to filter results by properties
+            filter: Optional Weaviate Filter object to filter results
+                by properties
 
         Returns:
             List[SearchResultItem]: List of search result items
@@ -178,7 +180,7 @@ class Retriever:
                 alpha=alpha,
                 limit=top_k,
                 return_metadata=MetadataQuery(score=True),
-                filter=filter,
+                filters=filter,
             )
 
             # Process results
@@ -230,7 +232,8 @@ class Retriever:
             collection: Collection name to search
             top_k: Number of results to return
             score_threshold: Minimum similarity score threshold
-            filter: Optional Weaviate Filter object to filter results by properties
+            filter: Optional Weaviate Filter object to filter results
+                by properties
 
         Returns:
             List[SearchResultItem]: List of search result items
@@ -255,7 +258,7 @@ class Retriever:
                 query=processed_query,
                 limit=top_k,
                 return_metadata=MetadataQuery(score=True),
-                filter=filter,
+                filters=filter,
             )
 
             # Process results

--- a/ragora/tests/unit/test_retriever.py
+++ b/ragora/tests/unit/test_retriever.py
@@ -132,7 +132,7 @@ class TestRetriever:
                     query="machine learning",
                     limit=5,
                     return_metadata=MetadataQuery(distance=True),
-                    filter=None,
+                    filters=None,
                 )
 
     def test_search_similar_empty_query(self, retriever):
@@ -184,7 +184,7 @@ class TestRetriever:
                     alpha=0.7,
                     limit=5,
                     return_metadata=MetadataQuery(score=True),
-                    filter=None,
+                    filters=None,
                 )
 
     def test_search_hybrid_invalid_alpha(self, retriever):
@@ -231,7 +231,7 @@ class TestRetriever:
                     query="machine learning",
                     limit=5,
                     return_metadata=MetadataQuery(score=True),
-                    filter=None,
+                    filters=None,
                 )
 
     def test_search_keyword_empty_query(self, retriever):
@@ -488,7 +488,7 @@ class TestRetriever:
                     query="machine learning",
                     limit=5,
                     return_metadata=MetadataQuery(distance=True),
-                    filter=test_filter,
+                    filters=test_filter,
                 )
 
     def test_search_hybrid_with_filter(
@@ -530,7 +530,7 @@ class TestRetriever:
                     alpha=0.7,
                     limit=5,
                     return_metadata=MetadataQuery(score=True),
-                    filter=test_filter,
+                    filters=test_filter,
                 )
 
     def test_search_keyword_with_filter(
@@ -570,7 +570,7 @@ class TestRetriever:
                     query="machine learning",
                     limit=5,
                     return_metadata=MetadataQuery(score=True),
-                    filter=test_filter,
+                    filters=test_filter,
                 )
 
     def test_search_with_none_filter(
@@ -605,5 +605,5 @@ class TestRetriever:
                     query="machine learning",
                     limit=5,
                     return_metadata=MetadataQuery(distance=True),
-                    filter=None,
+                    filters=None,
                 )


### PR DESCRIPTION
This commit updates the parameter naming from `filter` to `filters` in the `Retriever` class methods and their corresponding documentation. The changes enhance consistency across the codebase, improving clarity for users regarding the expected input for filtering search results. Additionally, unit tests have been adjusted to reflect this naming change, ensuring that all tests remain valid and functional.