### PR TITLE
fix: bug failure installing ragora during documentation generation workflow

### DIFF
--- a/.github/workflows/doc-generation.yaml
+++ b/.github/workflows/doc-generation.yaml
@@ -40,7 +40,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Extract version from git tag
+        id: extract_version
+        run: |
+          # Get the tag that HEAD points to (works for both release events and manual dispatch)
+          TAG_NAME=$(git describe --tags --exact-match HEAD 2>/dev/null || git tag --points-at HEAD | head -n 1)
+
+          if [ -z "${TAG_NAME}" ]; then
+            echo "Error: No git tag found at HEAD. Cannot determine version." >&2
+            exit 1
+          fi
+
+          # Extract version from tag (e.g., v1.3.0 -> 1.3.0)
+          VERSION="${TAG_NAME#v}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "Extracted version: ${VERSION} from git tag: ${TAG_NAME}"
+
       - name: Install documentation dependencies
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ env.VERSION }}
         run: |
           python -m pip install --upgrade pip
           pip install -e "ragora[docs]"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Set up the development environment:
 
 ```bash
 # Clone the repository
-git clone https://github.com/vahidlari/aiapps.git
+git clone https://github.com/vahidlari/ragora-core.git
 cd aiapps
 
 # Open in DevContainer (recommended)
@@ -96,7 +96,7 @@ Ragora uses Weaviate as its vector database. For users, download the pre-configu
 
 ```bash
 # Download from GitHub releases
-wget https://github.com/vahidlari/aiapps/releases/latest/download/ragora-database-server.tar.gz
+wget https://github.com/vahidlari/ragora-core/releases/latest/download/ragora-database-server.tar.gz
 tar -xzf ragora-database-server.tar.gz
 cd ragora-database-server
 ./database-manager.sh start
@@ -214,9 +214,9 @@ This project is licensed under the MIT License - see the [LICENSE](ragora/LICENS
 ## 🔗 Links
 
 - **PyPI Package**: [pypi.org/project/ragora](https://pypi.org/project/ragora) (coming soon)
-- **GitHub Repository**: [github.com/vahidlari/aiapps](https://github.com/vahidlari/aiapps)
-- **Issues**: [GitHub Issues](https://github.com/vahidlari/aiapps/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/vahidlari/aiapps/discussions)
+- **GitHub Repository**: [github.com/vahidlari/ragora-core](https://github.com/vahidlari/ragora-core)
+- **Issues**: [GitHub Issues](https://github.com/vahidlari/ragora-core/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/vahidlari/ragora-core/discussions)
 
 ## 🆘 Getting Help
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,7 +86,7 @@ The examples require a running Weaviate instance. Download the pre-configured da
 
 ```bash
 # Download from GitHub releases
-wget https://github.com/vahidlari/aiapps/releases/latest/download/ragora-database-server.tar.gz
+wget https://github.com/vahidlari/ragora-core/releases/latest/download/ragora-database-server.tar.gz
 
 # Extract and start
 tar -xzf ragora-database-server.tar.gz
@@ -322,8 +322,8 @@ After running the examples, you can:
 If you encounter issues or have questions:
 
 - **Check Documentation**: See [ragora/docs/](../ragora/docs/)
-- **Review Issues**: Search [GitHub Issues](https://github.com/vahidlari/aiapps/issues)
-- **Ask Questions**: Start a [GitHub Discussion](https://github.com/vahidlari/aiapps/discussions)
+- **Review Issues**: Search [GitHub Issues](https://github.com/vahidlari/ragora-core/issues)
+- **Ask Questions**: Start a [GitHub Discussion](https://github.com/vahidlari/ragora-core/discussions)
 - **Report Bugs**: Create a new issue with detailed information
 
 ## 🤝 Contributing Examples

--- a/ragora/README.md
+++ b/ragora/README.md
@@ -60,7 +60,7 @@ You need a Weaviate instance running. Download the pre-configured Ragora databas
 
 ```bash
 # Download from GitHub releases
-wget https://github.com/vahidlari/aiapps/releases/latest/download/ragora-database-server.tar.gz
+wget https://github.com/vahidlari/ragora-core/releases/latest/download/ragora-database-server.tar.gz
 
 # Extract and start
 tar -xzf ragora-database-server.tar.gz
@@ -214,7 +214,7 @@ Check out the [`ragora/examples/`](ragora/examples/) directory for more detailed
 
 ```bash
 # Clone the repository
-git clone https://github.com/vahidlari/aiapps.git
+git clone https://github.com/vahidlari/ragora-core.git
 cd aiapps/ragora
 
 # Install in development mode
@@ -275,11 +275,11 @@ Ragora builds on excellent open-source projects:
 
 ## 🔗 Links
 
-- **Repository**: [github.com/vahidlari/aiapps](https://github.com/vahidlari/aiapps)
+- **Repository**: [github.com/vahidlari/ragora-core](https://github.com/vahidlari/ragora-core)
 - **Documentation**: [docs/](docs/)
 - **Examples**: [examples/](../examples/)
-- **Issues**: [GitHub Issues](https://github.com/vahidlari/aiapps/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/vahidlari/aiapps/discussions)
+- **Issues**: [GitHub Issues](https://github.com/vahidlari/ragora-core/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/vahidlari/ragora-core/discussions)
 
 ## 📮 Contact
 

--- a/ragora/README.pypi.md
+++ b/ragora/README.pypi.md
@@ -2,8 +2,8 @@
 
 [![PyPI version](https://badge.fury.io/py/ragora.svg)](https://pypi.org/project/ragora/)
 [![Python versions](https://img.shields.io/pypi/pyversions/ragora.svg)](https://pypi.org/project/ragora/)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Vahidlari/aiApps/blob/main/ragora/LICENSE)
-[![GitHub stars](https://img.shields.io/github/stars/vahidlari/aiapps.svg)](https://github.com/vahidlari/aiapps)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/vahidlari/ragora-core/blob/main/ragora/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/vahidlari/ragora-core.svg)](https://github.com/vahidlari/ragora-core)
 
 **Build smarter, grounded, and transparent AI with Ragora.**
 
@@ -32,7 +32,7 @@ You need a Weaviate instance running. Download the pre-configured Ragora databas
 
 ```bash
 # Download from GitHub releases
-wget https://github.com/Vahidlari/aiApps/releases/download/v<x.y.z>/database_server-<x.y.z>.tar.gz
+wget https://github.com/vahidlari/ragora-core/releases/download/v<x.y.z>/database_server-<x.y.z>.tar.gz
 
 # Extract and start
 tar -xzf database_server-<x.y.z>.tar.gz
@@ -94,7 +94,7 @@ results = kbm.search("neural networks", strategy=SearchStrategy.HYBRID, alpha=0.
 
 - **[Tool Documentation](https://vahidlari.github.io/aiApps/)**: Overal tool documentation, including instructions to get started
 - **[API Reference](https://vahidlari.github.io/aiApps/api-reference/)**: Complete API documentation
-- **[Examples Directory](https://github.com/vahidlari/aiapps/tree/main/ragora/ragora/examples)**: Working code examples
+- **[Examples Directory](https://github.com/vahidlari/ragora-core/tree/main/ragora/ragora/examples)**: Working code examples
   - `basic_usage.py`: Basic usage examples and getting started
   - `advanced_usage.py`: Advanced features and custom pipelines
   - `email_usage_examples.py`: Email integration examples
@@ -103,11 +103,11 @@ results = kbm.search("neural networks", strategy=SearchStrategy.HYBRID, alpha=0.
 
 - **Python**: 3.11 or higher
 - **Weaviate**: 1.22.0 or higher (for vector storage)
-- **Dependencies**: See [requirements.txt](https://github.com/vahidlari/aiapps/blob/main/ragora/requirements.txt)
+- **Dependencies**: See [requirements.txt](https://github.com/vahidlari/ragora-core/blob/main/ragora/requirements.txt)
 
 ## 🤝 Contributing
 
-We welcome contributions! Please see our [Contributing Guidelines](https://github.com/vahidlari/aiapps/blob/main/ragora/docs/contributing.md) for:
+We welcome contributions! Please see our [Contributing Guidelines](https://github.com/vahidlari/ragora-core/blob/main/ragora/docs/contributing.md) for:
 
 - Setting up your development environment
 - Code style and standards
@@ -116,13 +116,13 @@ We welcome contributions! Please see our [Contributing Guidelines](https://githu
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](https://github.com/vahidlari/aiapps/blob/main/ragora/LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/vahidlari/ragora-core/blob/main/ragora/LICENSE) file for details.
 
 ## 🔗 Links
 
-- **Repository**: [github.com/vahidlari/aiapps](https://github.com/vahidlari/aiapps)
-- **Issues**: [GitHub Issues](https://github.com/vahidlari/aiapps/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/vahidlari/aiapps/discussions)
+- **Repository**: [github.com/vahidlari/ragora-core](https://github.com/vahidlari/ragora-core)
+- **Issues**: [GitHub Issues](https://github.com/vahidlari/ragora-core/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/vahidlari/ragora-core/discussions)
 
 ## 📮 Contact
 

--- a/ragora/pyproject.toml
+++ b/ragora/pyproject.toml
@@ -82,9 +82,9 @@ jupyter = [
 ragora = "ragora.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/vahidlari/aiapps"
-Repository = "https://github.com/vahidlari/aiapps"
-Issues = "https://github.com/vahidlari/aiapps/issues"
+Homepage = "https://github.com/vahidlari/ragora-core"
+Repository = "https://github.com/vahidlari/ragora-core"
+Issues = "https://github.com/vahidlari/ragora-core/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/ragora/ragora/__init__.py
+++ b/ragora/ragora/__init__.py
@@ -121,4 +121,4 @@ __all__ = [
 __author__ = "Vahid Lari"
 __email__ = "vahidlari@gmail.com"
 __description__ = "A knowledge base manager for LaTeX documents"
-__url__ = "https://github.com/vahidlari/aiapps"
+__url__ = "https://github.com/vahidlari/ragora-core"

--- a/tools/release-scripts/README.md
+++ b/tools/release-scripts/README.md
@@ -123,10 +123,10 @@ python format-release-notes.py <version> <repository> [milestone_summary_file]
 **Example:**
 ```bash
 # Without milestone summary
-python format-release-notes.py 1.2.0 Vahidlari/aiApps
+python format-release-notes.py 1.2.0 vahidlari/ragora-core
 
 # With milestone summary
-python format-release-notes.py 1.2.0 Vahidlari/aiApps milestone_summary.md
+python format-release-notes.py 1.2.0 vahidlari/ragora-core milestone_summary.md
 ```
 
 **Output:** Formatted markdown to stdout with:
@@ -149,7 +149,7 @@ create-version-metadata.sh <version> <git_commit> <git_branch> <repository>
 
 **Example:**
 ```bash
-bash create-version-metadata.sh 1.0.0 abc123def main Vahidlari/aiApps
+bash create-version-metadata.sh 1.0.0 abc123def main vahidlari/ragora-core
 ```
 
 **Creates:**
@@ -171,8 +171,8 @@ bash create-version-metadata.sh 1.0.0 abc123def main Vahidlari/aiApps
   "git_tag": "v1.0.0",
   "git_commit": "abc123def",
   "git_branch": "main",
-  "release_url": "https://github.com/Vahidlari/aiApps/releases/tag/v1.0.0",
-  "repository": "Vahidlari/aiApps"
+  "release_url": "https://github.com/vahidlari/ragora-core/releases/tag/v1.0.0",
+  "repository": "vahidlari/ragora-core"
 }
 ```
 
@@ -189,7 +189,7 @@ update-readme-version.sh <version> <repository>
 
 **Example:**
 ```bash
-bash update-readme-version.sh 1.0.0 Vahidlari/aiApps
+bash update-readme-version.sh 1.0.0 vahidlari/ragora-core
 ```
 
 **Actions:**
@@ -257,19 +257,19 @@ cd /workspaces/aiApps
 bash tools/release-scripts/check-release-commits.sh v1.0.0 HEAD
 
 # Test format release notes
-python tools/release-scripts/format-release-notes.py 1.2.0 Vahidlari/aiApps
+python tools/release-scripts/format-release-notes.py 1.2.0 vahidlari/ragora-core
 
 # Test metadata creation
 bash tools/release-scripts/create-version-metadata.sh \
   "1.0.0-test" \
   "abc123" \
   "test-branch" \
-  "Vahidlari/aiApps"
+  "vahidlari/ragora-core"
 
 # Test README update
 bash tools/release-scripts/update-readme-version.sh \
   "1.0.0-test" \
-  "Vahidlari/aiApps"
+  "vahidlari/ragora-core"
 
 # Check the results
 cat tools/database_server/config/VERSION

--- a/tools/release-scripts/create-version-metadata.sh
+++ b/tools/release-scripts/create-version-metadata.sh
@@ -7,7 +7,7 @@ set -e
 # Check arguments
 if [ "$#" -ne 4 ]; then
     echo "Usage: $0 <version> <git_commit> <git_branch> <repository>"
-    echo "Example: $0 1.0.0 abc123def main Vahidlari/aiApps"
+    echo "Example: $0 1.0.0 abc123def main vahidlari/ragora-core"
     exit 1
 fi
 

--- a/tools/release-scripts/format-release-notes.py
+++ b/tools/release-scripts/format-release-notes.py
@@ -10,7 +10,7 @@ Usage:
     python format-release-notes.py <version> <repository> [milestone_summary_file]
 
 Example:
-    python format-release-notes.py 1.2.0 Vahidlari/aiApps milestone_summary.md
+    python format-release-notes.py 1.2.0 vahidlari/ragora-core milestone_summary.md
 """
 
 import argparse
@@ -25,7 +25,7 @@ def format_installation_instructions(version: str, repository: str) -> str:
 
     Args:
         version: The release version (e.g., "1.2.0")
-        repository: The repository name (e.g., "Vahidlari/aiApps")
+        repository: The repository name (e.g., "vahidlari/ragora-core")
 
     Returns:
         Formatted markdown string with installation instructions
@@ -109,14 +109,16 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  %(prog)s 1.2.0 Vahidlari/aiApps
-  %(prog)s 1.2.0 Vahidlari/aiApps milestone_summary.md
+  %(prog)s 1.2.0 vahidlari/ragora-core
+  %(prog)s 1.2.0 vahidlari/ragora-core milestone_summary.md
         """,
     )
 
     parser.add_argument("version", help="Release version (e.g., 1.2.0)")
 
-    parser.add_argument("repository", help="Repository name (e.g., Vahidlari/aiApps)")
+    parser.add_argument(
+        "repository", help="Repository name (e.g., vahidlari/ragora-core)"
+    )
 
     parser.add_argument(
         "milestone_summary_file",

--- a/tools/release-scripts/tests/test_format_release_notes.py
+++ b/tools/release-scripts/tests/test_format_release_notes.py
@@ -36,14 +36,14 @@ def run_script(args, expect_success=True):
 @pytest.mark.unit
 def test_basic_installation_instructions():
     """Test basic installation instructions without milestone summary."""
-    stdout, stderr, returncode = run_script(["1.2.0", "Vahidlari/aiApps"])
+    stdout, stderr, returncode = run_script(["1.2.0", "vahidlari/ragora-core"])
 
     assert returncode == 0
     assert "## 📦 Installation" in stdout
     assert "pip install ragora==1.2.0" in stdout
     assert "v1.2.0/ragora-1.2.0-py3-none-any.whl" in stdout
     assert "v1.2.0/ragora-1.2.0.tar.gz" in stdout
-    assert "Vahidlari/aiApps" in stdout
+    assert "vahidlari/ragora-core" in stdout
 
 
 @pytest.mark.unit
@@ -54,7 +54,7 @@ def test_with_milestone_summary(temp_dir, sample_milestone_content):
     milestone_file.write_text(sample_milestone_content)
 
     stdout, stderr, returncode = run_script(
-        ["1.2.0", "Vahidlari/aiApps", str(milestone_file)]
+        ["1.2.0", "vahidlari/ragora-core", str(milestone_file)]
     )
 
     assert returncode == 0
@@ -68,7 +68,7 @@ def test_with_milestone_summary(temp_dir, sample_milestone_content):
 def test_missing_milestone_file():
     """Test with missing milestone summary file (should not fail)."""
     stdout, stderr, returncode = run_script(
-        ["1.2.0", "Vahidlari/aiApps", "/nonexistent/file.md"]
+        ["1.2.0", "vahidlari/ragora-core", "/nonexistent/file.md"]
     )
 
     assert returncode == 0
@@ -131,7 +131,7 @@ def test_with_existing_milestone_fixture(fixtures_dir):
 
     if milestone_file.exists():
         stdout, stderr, returncode = run_script(
-            ["1.2.0", "Vahidlari/aiApps", str(milestone_file)]
+            ["1.2.0", "vahidlari/ragora-core", str(milestone_file)]
         )
 
         assert returncode == 0

--- a/tools/release-scripts/update-readme-version.sh
+++ b/tools/release-scripts/update-readme-version.sh
@@ -7,7 +7,7 @@ set -e
 # Check arguments
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 <version> <repository>"
-    echo "Example: $0 1.0.0 Vahidlari/aiApps"
+    echo "Example: $0 1.0.0 vahidlari/ragora-core"
     exit 1
 fi
 


### PR DESCRIPTION
This pull request updates all references to the GitHub repository from `vahidlari/aiapps` (and variations in casing) to the new canonical repository name `vahidlari/ragora-core` across the codebase, documentation, release scripts, and tests. Additionally, it improves the documentation build workflow by ensuring the correct version is extracted from git tags and passed to the environment during documentation generation.

The most important changes are:

**Repository Reference Updates:**

* All links, URLs, badges, and example commands in documentation files (`README.md`, `ragora/README.md`, `ragora/README.pypi.md`, and `examples/README.md`) now point to `vahidlari/ragora-core` instead of `vahidlari/aiapps`. This includes download links, discussions, issues, and contributing guidelines. 

**Release Scripts and Tests:**

* All shell and Python scripts in `tools/release-scripts/` and their documentation now use `vahidlari/ragora-core` as the repository argument in usage examples, test cases, and output. This ensures consistency for future releases and automation. 

**Documentation Build Workflow:**

* The `.github/workflows/doc-generation.yaml` workflow now extracts the version from the git tag at `HEAD` and sets it in the environment variable `SETUPTOOLS_SCM_PRETEND_VERSION` before installing documentation dependencies. This ensures the documentation is built with the correct version metadata during releases.

Closes #94 